### PR TITLE
Add utility to simplify working with OverlayPlotContainer.

### DIFF
--- a/app_common/chaco/overlay_plot_container_utils.py
+++ b/app_common/chaco/overlay_plot_container_utils.py
@@ -1,0 +1,21 @@
+""" Utilities to build flexible overlaid plots using an OverlayPlotContainer.
+
+The goal is to bridge the gap between the ease of use of chaco's Plot and the
+flexibility power of the OverlayPlotContainer classes.
+"""
+
+
+def align_renderer(renderer, axis, dim="index"):
+    """ Align a renderer's index or value mapper along provided axis.
+
+    The purpose of this function is to align a renderer on an existing PlotAxis
+    without the nuclear option of setting the renderer's mapper to the axis
+    mapper. Obviously, making the 2 mappers the same object works well to align
+    multiple plots with each other.
+
+    But in some situations, having the same mappers leads to
+    """
+    axis.mapper.range.add(getattr(renderer, dim))
+    mapper = getattr(renderer, dim + "_mapper")
+    mapper.range.low = axis.mapper.range.low
+    mapper.range.high = axis.mapper.range.high

--- a/app_common/chaco/overlay_plot_container_utils.py
+++ b/app_common/chaco/overlay_plot_container_utils.py
@@ -13,7 +13,21 @@ def align_renderer(renderer, axis, dim="index"):
     mapper. Obviously, making the 2 mappers the same object works well to align
     multiple plots with each other.
 
-    But in some situations, having the same mappers leads to
+    But having the same mappers leads to the wrong behavior of the ZoomTool's
+    box drawing feature. The only way to make it work is for mappers to remain
+    distinct but aligned. This function does that.
+
+    Parameters
+    ----------
+    renderer : AbstractPlotRenderer
+        Renderer to align.
+
+    axis : PlotAxis
+        Axis to align the renderer along.
+
+    dim : str
+        Dimension along which to align the renderer. Valid values are "index"
+        and "value".
     """
     axis.mapper.range.add(getattr(renderer, dim))
     mapper = getattr(renderer, dim + "_mapper")

--- a/app_common/chaco/tests/test_overlay_plot_container_utils.py
+++ b/app_common/chaco/tests/test_overlay_plot_container_utils.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-import numpy as np
 from chaco.api import add_default_axes, create_line_plot
 from app_common.chaco.overlay_plot_container_utils import align_renderer
 

--- a/app_common/chaco/tests/test_overlay_plot_container_utils.py
+++ b/app_common/chaco/tests/test_overlay_plot_container_utils.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+import numpy as np
+from chaco.api import add_default_axes, create_line_plot
+from app_common.chaco.overlay_plot_container_utils import align_renderer
+
+
+class TestAlignRenderer(TestCase):
+
+    def test_align_line_plot(self):
+        l1 = [1, 2, 3]
+        l2 = [3, 4, 5]
+        plot1 = create_line_plot((l1, l2))
+        left_axis1, bottom_axis1 = add_default_axes(plot1)
+        self.assertEqual(bottom_axis1.mapper.range.low, l1[0])
+        self.assertEqual(bottom_axis1.mapper.range.high, l1[-1])
+
+        self.assertEqual(left_axis1.mapper.range.low, l2[0])
+        self.assertEqual(left_axis1.mapper.range.high, l2[-1])
+
+        plot2 = create_line_plot((l2, l1))
+        left_axis2, bottom_axis2 = add_default_axes(plot2)
+        self.assertNotEqual(bottom_axis2.mapper.range.low,
+                            bottom_axis1.mapper.range.low)
+        self.assertNotEqual(bottom_axis2.mapper.range.high,
+                            bottom_axis1.mapper.range.high)
+
+        self.assertNotEqual(left_axis2.mapper.range.low,
+                            left_axis1.mapper.range.low)
+        self.assertNotEqual(left_axis2.mapper.range.high,
+                            left_axis1.mapper.range.high)
+
+        align_renderer(plot2, bottom_axis1)
+
+        self.assertEqual(bottom_axis2.mapper.range.low,
+                         bottom_axis1.mapper.range.low)
+        self.assertEqual(bottom_axis2.mapper.range.high,
+                         bottom_axis1.mapper.range.high)
+
+        align_renderer(plot2, left_axis1, dim="value")
+
+        self.assertEqual(left_axis2.mapper.range.low,
+                         left_axis1.mapper.range.low)
+        self.assertEqual(left_axis2.mapper.range.high,
+                         left_axis1.mapper.range.high)


### PR DESCRIPTION
Add a utility to align a chaco renderer along a provided chaco `PlotAxis` without forcing them to have the same mapper. Useful when wanting to combine the `ZoomTool` with a multi y-axis `OverlayPlotContainer`.