### PR TITLE
Enh: show/hide contraints plot container

### DIFF
--- a/app_common/chaco/constraints_plot_container_manager.py
+++ b/app_common/chaco/constraints_plot_container_manager.py
@@ -18,7 +18,7 @@ class ConstraintsPlotContainerManager(HasStrictTraits):
 
     #: The collection of Plots in the container. Each Plot is mapped to a key
     #: for caching, and hide/show purposes.
-    plot_map = Dict(Any, Instance(BasePlotContainer))
+    plot_map = Dict
 
     #: Remove a Plot from the container if there are no curves being rendered.
     #: Set to `False` to avoid the resizing of the Plots in the container
@@ -65,11 +65,13 @@ class ConstraintsPlotContainerManager(HasStrictTraits):
     def add_plot(self, plot_key, plot, position=None):
         """ Add new Plot to container, or update if key already exists.
         """
-        self.plot_map[plot_key] = plot
         if position is None:
+            position = len(self.plot_map)
             self.container.add(plot)
         else:
             self.container.insert(position, plot)
+
+        self.plot_map[plot_key] = (plot, position)
         self.refresh_container()
 
     def delete_plot(self, plot_key, plot):
@@ -82,25 +84,27 @@ class ConstraintsPlotContainerManager(HasStrictTraits):
     def hide_plot(self, plot_key):
         """ Retrieve Plot for specific log type if exists, create  it otherwise
         """
-        plot = self.plot_map.get(plot_key, None)
-        if plot is None:
+        result = self.plot_map.get(plot_key, None)
+        if result is None:
             msg = "Plot key requested ({}) not in cache".format(plot_key)
             logger.error(msg)
             raise ValueError(msg)
 
+        plot, position = result
         self.container.remove(plot)
         self.refresh_container()
 
     def show_plot(self, plot_key):
         """ Retrieve Plot for specific log type if exists, create  it otherwise
         """
-        plot = self.plot_map.get(plot_key, None)
-        if plot is None:
+        result = self.plot_map.get(plot_key, None)
+        if result is None:
             msg = "Plot key requested ({}) not in cache".format(plot_key)
             logger.error(msg)
             raise ValueError(msg)
 
-        self.container.add(plot)
+        plot, position = result
+        self.container.insert(position, plot)
         self.refresh_container()
 
     def _create_container(self):

--- a/app_common/chaco/constraints_plot_container_manager.py
+++ b/app_common/chaco/constraints_plot_container_manager.py
@@ -1,7 +1,6 @@
 import logging
 
-from traits.api import Any, Bool, Dict, Enum, HasStrictTraits, Instance, Int
-from chaco.base_plot_container import BasePlotContainer
+from traits.api import Bool, Dict, Enum, HasStrictTraits, Instance, Int
 from enable.layout.api import align, vbox, hbox, grid
 
 from app_common.chaco.constraints_plot_container import \
@@ -50,7 +49,10 @@ class ConstraintsPlotContainerManager(HasStrictTraits):
     padding_right = Int(10)
 
     def init(self):
-        """ Initialize the plots.
+        """ Initialize the plot container.
+
+        Note done automatically, maybe in case the user wants to edit the
+        layout before actually creating the container.
         """
         self._create_container()
 
@@ -121,33 +123,23 @@ class ConstraintsPlotContainerManager(HasStrictTraits):
         """ Returns a list of constraints that is meant to be passed to
         a ConstraintsContainer.
         """
-        constraints = []
-
         # NOTE: inequality expressions seem a lil shaky in that it requires
         # some tweaking to finding a set of constraints that works well !
         # But this is much better than manually tweaking padding etc.
 
-        # Another option is to simply calculate the values of the height etc
-        # and set it as simple inequalities (as opposed to using height as
-        # another variable in the expressions)
-
         # FIXME: also, the layouts can prob. be specified as input similar to
         # the other plot properties.
 
-        # split components into groups. For now, just UV and others
         components = container.components
-
-        # NOTE: looks like every comp in the container needs a constraint,
-        # else they get messed up or ignored.
 
         # create an ordered (top to bottom) list of components
         layout_helper = LAYOUT_MAPS[self.layout_type]
-        constraints.extend([
+        constraints = [
             layout_helper(*components, spacing=self.layout_spacing,
                           margins=self.layout_margins),
             # align widths of all components to be the same
             align('layout_width', *components),
             # align heights of *other* components to be the same
             align('layout_height', *components),
-        ])
+        ]
         return constraints

--- a/app_common/chaco/constraints_plot_container_manager.py
+++ b/app_common/chaco/constraints_plot_container_manager.py
@@ -1,6 +1,6 @@
 import logging
 
-from traits.api import Bool, Dict, Enum, HasStrictTraits, Instance, Int
+from traits.api import Dict, Enum, HasStrictTraits, Instance, Int
 from enable.layout.api import align, vbox, hbox, grid
 
 from app_common.chaco.constraints_plot_container import \
@@ -18,11 +18,6 @@ class ConstraintsPlotContainerManager(HasStrictTraits):
     #: The collection of Plots in the container. Each Plot is mapped to a key
     #: for caching, and hide/show purposes.
     plot_map = Dict
-
-    #: Remove a Plot from the container if there are no curves being rendered.
-    #: Set to `False` to avoid the resizing of the Plots in the container
-    #: when the empty Plot is removed.
-    remove_empty_plot = Bool(True)
 
     #: The instance of PlotContainer that contains all the Plots.
     container = Instance(ConstraintsPlotContainer)

--- a/app_common/chaco/tests/test_constraints_plot_container_manager.py
+++ b/app_common/chaco/tests/test_constraints_plot_container_manager.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+
+from chaco.api import Plot
+from app_common.chaco.constraints_plot_container_manager import \
+    ConstraintsPlotContainerManager
+
+
+class TestConstraintsPlotContainerManager(TestCase):
+    def test_create_empty(self):
+        manager = ConstraintsPlotContainerManager()
+        self.assertEqual(manager.plot_map, {})
+        self.assertIsNone(manager.container)
+        manager.init()
+        self.assertEqual(manager.container.components, [])
+
+    def test_add_1_plot(self):
+        manager = ConstraintsPlotContainerManager()
+        manager.init()
+        self.assertEqual(manager.container.components, [])
+        plot = Plot()
+        manager.add_plot("0", plot)
+        self.assertEqual(manager.container.components, [plot])
+
+    def test_add_2_plots(self):
+        manager = ConstraintsPlotContainerManager()
+        manager.init()
+        self.assertEqual(manager.container.components, [])
+        plot = Plot()
+        manager.add_plot("0", plot)
+        self.assertEqual(manager.container.components, [plot])
+        plot2 = Plot()
+        manager.add_plot("foobar", plot2)
+        self.assertEqual(manager.container.components, [plot, plot2])
+
+    def test_show_hide_2_plots(self):
+        manager = ConstraintsPlotContainerManager()
+        manager.init()
+        self.assertEqual(manager.container.components, [])
+        plot = Plot()
+        manager.add_plot("0", plot)
+        plot2 = Plot()
+        manager.add_plot("foobar", plot2)
+        self.assertEqual(manager.container.components, [plot, plot2])
+        manager.hide_plot("0")
+        self.assertEqual(manager.container.components, [plot2])
+        manager.show_plot("0")
+        self.assertEqual(manager.container.components, [plot, plot2])
+        manager.hide_plot("foobar")
+        self.assertEqual(manager.container.components, [plot])
+        manager.show_plot("foobar")
+        self.assertEqual(manager.container.components, [plot, plot2])
+
+    def test_show_hide_non_existent_plot(self):
+        manager = ConstraintsPlotContainerManager()
+        manager.init()
+        self.assertEqual(manager.container.components, [])
+        plot = Plot()
+        manager.add_plot("0", plot)
+        with self.assertRaises(ValueError):
+            manager.hide_plot("NON-EXISTENT")


### PR DESCRIPTION
- Store the position of a plot when adding it to a `ConstraintsPlotContainerManager`. Use it to show/hide it in the correct position.
- Adds a few unit tests for that class.
- Clean up the implementation removing unused attribute and irrelevant comments.

Avoids the pybleau bug: https://github.com/KBIbiopharma/pybleau/issues/57