### PR TITLE
FEAT: Control DFScatterInspector overlay formatting

### DIFF
--- a/app_common/chaco/scatter_position_tool.py
+++ b/app_common/chaco/scatter_position_tool.py
@@ -103,16 +103,22 @@ class DataframeScatterOverlay(TextBoxOverlay):
     #: Function which takes an inspector and an index and returns info string
     message_for_data = Callable
 
+    #: Background color of the text overlay
     bgcolor = Str("black")
 
+    #: Transparency of the text overlay
     alpha = Float(0.6)
 
+    #: Text color of the text overlay
     text_color = Str("white")
 
+    #: Border color for the text overlay
     border_color = "none"
 
+    #: Whether to include index value, or just column values in text overlay
     include_index = Bool
 
+    #: Formatting(s) for the DF values, optionally by columns. E.g. ".3f"
     val_fmts = Either(Dict, Str)
 
     def _val_fmts_default(self):

--- a/app_common/chaco/scatter_position_tool.py
+++ b/app_common/chaco/scatter_position_tool.py
@@ -121,8 +121,7 @@ class DataframeScatterOverlay(TextBoxOverlay):
     #: Formatting(s) for the DF values, optionally by columns. E.g. ".3f"
     val_fmts = Either(Dict, Str)
 
-    def _val_fmts_default(self):
-        return ""
+    # Traits listener methods -------------------------------------------------
 
     @on_trait_change('inspectors:inspector_event')
     def scatter_point_found(self, inspector, name, event):
@@ -134,6 +133,8 @@ class DataframeScatterOverlay(TextBoxOverlay):
 
         self.visible = len(self.text) > 0
         self.component.request_redraw()
+
+    # Traits initialization methods -------------------------------------------
 
     def _message_for_data_default(self):
         def show_data(inspector, data_idx):
@@ -153,6 +154,9 @@ class DataframeScatterOverlay(TextBoxOverlay):
                 elements.append(col_element)
             return "\n".join(elements)
         return show_data
+
+    def _val_fmts_default(self):
+        return ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the ability to control the formatting of the DF values displayed by the default overlay text builder.

Allows users to control the precision of all values with something like:
```
overlay = DataframeScatterOverlay(inspectors=[inspector],
                                          val_fmts=":.2f")
```
or just of some columns with something like
```
overlay = DataframeScatterOverlay(inspectors=[inspector],
                                          val_fmts={"y": ":.2f"})
```