### PR TITLE
Support passing a single inspector.

### DIFF
--- a/app_common/chaco/scatter_position_tool.py
+++ b/app_common/chaco/scatter_position_tool.py
@@ -121,6 +121,13 @@ class DataframeScatterOverlay(TextBoxOverlay):
     #: Formatting(s) for the DF values, optionally by columns. E.g. ".3f"
     val_fmts = Either(Dict, Str)
 
+    def __init__(self, **traits):
+        if "inspectors" in traits and \
+                isinstance(traits["inspectors"], ScatterInspector):
+            traits["inspectors"] = [traits["inspectors"]]
+
+        super(DataframeScatterOverlay, self).__init__(**traits)
+
     # Traits listener methods -------------------------------------------------
 
     @on_trait_change('inspectors:inspector_event')

--- a/app_common/chaco/tests/test_scatter_position_tool.py
+++ b/app_common/chaco/tests/test_scatter_position_tool.py
@@ -52,6 +52,16 @@ class TestScatterPositionTool(TestCase, UnittestTools, EnableTestAssistant):
         # Default plot has a title and a legend, both overlays
         self.assertEqual(len(self.plot.overlays), 2)
 
+    def test_add_tool_to_plot_manually_inspectors_as_obj(self):
+        """ Make sure we """
+        renderer = self.plot.plot(("x", "y"), type="scatter")[0]
+        inspector = DataframeScatterInspector(data=self.df, component=renderer)
+        renderer.tools.append(inspector)
+        overlay = DataframeScatterOverlay(inspectors=inspector)
+        self.plot.overlays.append(overlay)
+
+        self.assertEqual(overlay.inspectors, [inspector])
+
     def test_add_tool_to_plot_manually(self):
         renderer = self.plot.plot(("x", "y"), type="scatter")[0]
         inspector = DataframeScatterInspector(data=self.df, component=renderer)

--- a/app_common/chaco/tests/test_scatter_position_tool.py
+++ b/app_common/chaco/tests/test_scatter_position_tool.py
@@ -53,7 +53,7 @@ class TestScatterPositionTool(TestCase, UnittestTools, EnableTestAssistant):
         self.assertEqual(len(self.plot.overlays), 2)
 
     def test_add_tool_to_plot_manually_inspectors_as_obj(self):
-        """ Make sure we """
+        """ Make sure we can build the overlay passing a single inspector."""
         renderer = self.plot.plot(("x", "y"), type="scatter")[0]
         inspector = DataframeScatterInspector(data=self.df, component=renderer)
         renderer.tools.append(inspector)


### PR DESCRIPTION
Simplify creating a `DFScatterOverlay` from a single inspector:
```
        ...
        inspector = DataframeScatterInspector(data=df, component=renderer)
        overlay = DataframeScatterOverlay(inspectors=inspector)
```
rather than requiring to pass a list of inspectors.