### PR TITLE
Feature: add support for an http logger

### DIFF
--- a/app_common/pyface/logging_utils.py
+++ b/app_common/pyface/logging_utils.py
@@ -71,7 +71,8 @@ def action_monitoring(action_name, log_folder="", logger=None,
     if logger is None:
         logger = local_logger
 
-    logger.log(logging_level, "Action '{}' requested...".format(action_name))
+    msg = 'Action requested: {}'.format(action_name)
+    logger.log(logging_level, msg)
     try:
         yield
     except Exception as e:

--- a/app_common/pyface/logging_utils.py
+++ b/app_common/pyface/logging_utils.py
@@ -27,7 +27,8 @@ def get_log_file(log_folder=""):
 
 
 @contextmanager
-def action_monitoring(action_name, log_folder="", logger=None, allow_gui=True,
+def action_monitoring(action_name, log_folder="", logger=None,
+                      logging_level=logging.INFO, allow_gui=True,
                       gui_title='Error', gui_severity='error',
                       feedback_menu_name="Help > Submit feedback/Report bug"):
     """ Context manager to provide monitoring & error handling for some action.
@@ -50,6 +51,9 @@ def action_monitoring(action_name, log_folder="", logger=None, allow_gui=True,
         Instance of the logger to use for monitoring. If not provided, will use
         the local logger.
 
+    logging_level : int
+        Level at which to report requested actions in logging.
+
     allow_gui : bool
         Whether to allow for a message dialog to be displayed to the user in
         case of an Exception.
@@ -67,7 +71,7 @@ def action_monitoring(action_name, log_folder="", logger=None, allow_gui=True,
     if logger is None:
         logger = local_logger
 
-    logger.debug("Action '{}' requested...".format(action_name))
+    logger.log(logging_level, "Action '{}' requested...".format(action_name))
     try:
         yield
     except Exception as e:
@@ -89,14 +93,3 @@ def action_monitoring(action_name, log_folder="", logger=None, allow_gui=True,
     else:
         msg = "Action '{}' performed successfully.".format(action_name)
         logger.debug(msg)
-
-
-def add_stream_handler_to_root_logger():
-    """ Add a development handler to root logger for quick setup.
-    """
-    root_logger = logging.getLogger()
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.DEBUG)
-    root_logger.addHandler(handler)
-    root_logger.setLevel(logging.DEBUG)
-    return root_logger

--- a/app_common/pyface/logging_utils.py
+++ b/app_common/pyface/logging_utils.py
@@ -71,7 +71,7 @@ def action_monitoring(action_name, log_folder="", logger=None,
     if logger is None:
         logger = local_logger
 
-    msg = 'Action requested: {}'.format(action_name)
+    msg = f'Action requested: {action_name}'
     logger.log(logging_level, msg)
     try:
         yield
@@ -92,5 +92,5 @@ def action_monitoring(action_name, log_folder="", logger=None,
 
             message_dialog(None, msg, title=gui_title, severity=gui_severity)
     else:
-        msg = "Action '{}' performed successfully.".format(action_name)
+        msg = f"Action performed successfully: {action_name}"
         logger.debug(msg)

--- a/app_common/std_lib/logging_utils.py
+++ b/app_common/std_lib/logging_utils.py
@@ -140,6 +140,8 @@ def http_logging_handler(url="", pkg_list=None, dt_fmt="", logging_level=INFO,
 
         try:
             logger.log(logging_level+10, "Testing new remote handler...")
+            msg = "Remote handler seems to be working normally."
+            logger.debug(msg)
         except Exception as e:
             logger.handlers.remove(http_handler)
             msg = "Failed to issue a log call, probably because of the " \

--- a/app_common/std_lib/logging_utils.py
+++ b/app_common/std_lib/logging_utils.py
@@ -1,21 +1,27 @@
-from __future__ import print_function
-
+"""
+"""
 import time
-import logging
+from logging import DEBUG, FileHandler, Formatter, getLogger, Handler, INFO, \
+    StreamHandler, WARNING
+from datetime import datetime
 import os
 from os.path import isdir, join
-from six import string_types
+import requests
+from uuid import uuid4
+
+from app_common.std_lib.os_utils import collect_user_name
 
 
-def initialize_logging(logging_level="WARNING", log_file=None, log_dir=".",
-                       prefix=None, include_console=True):
+def initialize_logging(logging_level=WARNING, log_file=None, log_dir=".",
+                       prefix=None, include_console=True, include_http=False,
+                       http_logger_kw=None):
     """ Set up logging with a console handler and optionally a file handler.
 
     Parameters
     ----------
     logging_level : str or int, optional
-        Level of sensitivity of the console handler. Valid values are 'NOTSET',
-        'DEBUG', 'WARNING', 'ERROR', 'CRITICAL' or an integer value.
+        Level of sensitivity of the **console handler**. Valid values are
+        'NOTSET', 'DEBUG', 'WARNING', 'ERROR', 'CRITICAL' or an integer value.
 
     log_file : str or None, optional
         The name of the log file. If this is None, the name will be set from
@@ -32,40 +38,38 @@ def initialize_logging(logging_level="WARNING", log_file=None, log_dir=".",
     include_console : bool
         Whether to include a console logging handler.
 
+    include_http : bool
+        Whether to include an HTTP logging handler.
+
+    http_logger_kw : dict
+        http logging keyword arguments, passed to
+
     Returns
     -------
     str
         Path to the log file written to, if any.
     """
     # Initial clean up if needed (useful for multiple runs in ipython)
-    root_logger = logging.getLogger()
+    root_logger = getLogger()
     if root_logger.handlers:
         root_logger.handlers = []
 
     fmt = '%(asctime)s %(levelname)-8.8s [%(name)s:%(lineno)s] %(message)s'
     datefmt = '%Y-%m-%d %H:%M:%S'
-    formatter = logging.Formatter(fmt, datefmt)
+    formatter = Formatter(fmt, datefmt)
 
-    root_logger.setLevel(logging.DEBUG)
+    root_logger.setLevel(DEBUG)
 
     if include_console:
-        sh = logging.StreamHandler()
-        if isinstance(logging_level, string_types):
-            try:
-                sh.setLevel(getattr(logging, logging_level))
-            except AttributeError:
-                msg = "Invalid logging_level value: {}".format(logging_level)
-                raise ValueError(msg)
-        else:
-            sh.setLevel(logging_level)
-
+        sh = StreamHandler()
+        sh.setLevel(logging_level)
         sh.setFormatter(formatter)
         root_logger.addHandler(sh)
 
     # If no file provided, create one from prefix, log_dir and datetime:
+    start_dt = time.strftime("%Y-%m-%d-%H-%M-%S")
     if log_file is None and prefix is not None:
-        log_file_template = prefix + "_%Y-%m-%d-%H-%M-%S.log"
-        log_file = time.strftime(log_file_template)
+        log_file = prefix + "_{}.log".format(start_dt)
 
         if not isdir(log_dir):
             os.makedirs(log_dir)
@@ -73,11 +77,137 @@ def initialize_logging(logging_level="WARNING", log_file=None, log_dir=".",
         log_file = join(log_dir, log_file)
 
     if log_file:
-        log_fh = logging.FileHandler(log_file, encoding="utf-8")
-        log_fh.setLevel(logging.DEBUG)
+        log_fh = FileHandler(log_file, encoding="utf-8")
+        log_fh.setLevel(DEBUG)
         log_fh.setFormatter(formatter)
         root_logger.addHandler(log_fh)
         print("Logging setup. For details on current run, refer to this log "
               "file : {!r}".format(log_file))
 
+    if include_http:
+        try:
+            http_logging_handler(start_dt=start_dt, **http_logger_kw)
+        except Exception as e:
+            msg = "Failed to create the remote handler. Error was {}".format(e)
+            root_logger.error(msg)
+
     return log_file
+
+
+def http_logging_handler(url="", pkg_list=None, dt_fmt="", logging_level=INFO,
+                         **kwargs):
+    """ Create and add HTTP handler to send logging calls to remote API.
+
+    Parameters
+    ----------
+    url : str
+        Address of the host including the http prefix, the address of the host,
+        optionally the port and the path to the REST end point to send the POST
+        request to.
+
+    kwargs : dict
+        Attributes to the CustomHTTPHandler. In particular, it needs to specify
+        an app_name, start_dt to be combined and used as an identifier of a
+        single session. Should also include any additional data that the API
+        end point needs or that should be stored.
+
+    pkg_list : list
+        List of package names to use this handler on. NOTE: this handler cannot
+        be used on the root handler, because that creates a RecursionError due
+        to the way requests.post is implemented.
+
+    dt_fmt : str, optional
+        Custom formatting for the UTC datetime to be passed to the logging
+        call.
+
+    logging_level : int, optional
+        Level above which to send log call to HTTP handler. Defaults to INFO.
+    """
+    if pkg_list is None:
+        pkg_list = ["app_common"]
+
+    if not dt_fmt:
+        dt_fmt = "%Y/%m/%d %H:%M:%S"
+
+    http_handler = CustomHTTPHandler(url, dt_fmt=dt_fmt, **kwargs)
+    http_handler.setLevel(logging_level)
+
+    # Only remote log the application's messages to avoid noise and
+    # RecursionError because requests sends logging messages:
+    for pkg in pkg_list:
+        logger = getLogger(pkg)
+        logger.addHandler(http_handler)
+
+        try:
+            logger.log(logging_level+10, "Testing new remote handler...")
+        except Exception as e:
+            logger.handlers.remove(http_handler)
+            msg = "Failed to issue a log call, probably because of the " \
+                  "remote handler. Removed the remote handler. Error was '{}'."
+            msg = msg.format(e)
+            logger.error(msg)
+        finally:
+            break
+
+    return http_handler
+
+
+class CustomHTTPHandler(Handler):
+    """ Custom HTTPHandler passing the HTTP request using the requests.post
+    method, since it tends to be more stable for REST API end points.
+    """
+    def __init__(self, url, app_name="", start_dt="", dt_fmt="", **adtl_data):
+        """ Initialize the instance with the request URL and all parameters.
+        """
+        super(CustomHTTPHandler, self).__init__()
+        self.url = url
+        self.app_name = app_name
+        self.adtl_data = adtl_data
+        self.start_dt = start_dt
+        self.dt_fmt = dt_fmt
+
+    def emit(self, record):
+        """ Custom implementation of emit using requests.post since it tends to
+        work more easily with REST API end points.
+        """
+        data = self.map_log_record(record)
+        # Build a valid json string with the data to record:
+        data_str = str(data).replace("'", '"')
+        response = requests.post(self.url, data=data_str)
+        return response
+
+    def map_log_record(self, record):
+        """ Custom implementation of mapping the log record into a dict.
+        """
+        # Generate utc datetime since default logging collects local time:
+        utc_datetime = datetime.strftime(datetime.utcnow(), self.dt_fmt)
+        username = collect_user_name()
+        # This log_id should be unique and constant throughout a tool
+        # usage:
+        session_id = self.app_name + ":" + username + ":" + self.start_dt
+        data = {
+            "log_id": str(uuid4()),
+            "session_id": session_id,
+            "app_name": self.app_name,
+            'user': username,
+            "pkg": record.name,
+            'level_no': record.levelno,
+            'line_no': record.lineno,
+            'func_name': record.funcName,
+            'utc_timestamp': utc_datetime,
+            'msg': record.msg
+        }
+        data.update(self.adtl_data)
+
+        return data
+
+
+def add_stream_handler(logging_level=DEBUG):
+    """ Add a development handler to root logger for quick setup.
+    """
+    root_logger = getLogger()
+    handler = StreamHandler()
+    handler.setLevel(logging_level)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging_level)
+    return root_logger

--- a/app_common/std_lib/logging_utils.py
+++ b/app_common/std_lib/logging_utils.py
@@ -2,11 +2,12 @@
 applications.
 """
 import time
-from logging import DEBUG, FileHandler, Formatter, getLogger, Handler, INFO, \
+from logging import DEBUG, FileHandler, Formatter, getLogger, INFO, \
     StreamHandler, WARNING
 import os
 from os.path import isdir, join
 
+from .remote_logging_handler import RequestsHTTPHandler
 
 
 def initialize_logging(logging_level=WARNING, log_file=None, log_dir=".",
@@ -91,8 +92,8 @@ def initialize_logging(logging_level=WARNING, log_file=None, log_dir=".",
     return log_file
 
 
-def http_logging_handler(url="", pkg_list=None, dt_fmt="", logging_level=INFO,
-                         handler_klass=CustomHTTPHandler, **kwargs):
+def http_logging_handler(url="", dt_fmt="", logging_level=INFO,
+                         handler_klass=RequestsHTTPHandler, **kwargs):
     """ Create and add HTTP handler to send logging calls to remote API.
 
     Parameters
@@ -123,7 +124,7 @@ def http_logging_handler(url="", pkg_list=None, dt_fmt="", logging_level=INFO,
     if not dt_fmt:
         dt_fmt = "%Y/%m/%d %H:%M:%S"
 
-    http_handler = CustomHTTPHandler(url, dt_fmt=dt_fmt, **kwargs)
+    http_handler = handler_klass(url, dt_fmt=dt_fmt, **kwargs)
     http_handler.setLevel(logging_level)
 
     logger = getLogger()

--- a/app_common/std_lib/logging_utils.py
+++ b/app_common/std_lib/logging_utils.py
@@ -1,4 +1,5 @@
-"""
+""" Utilities to quickly and consistently add logging infrastruture for
+applications.
 """
 import time
 from logging import DEBUG, FileHandler, Formatter, getLogger, Handler, INFO, \
@@ -123,33 +124,25 @@ def http_logging_handler(url="", pkg_list=None, dt_fmt="", logging_level=INFO,
     logging_level : int, optional
         Level above which to send log call to HTTP handler. Defaults to INFO.
     """
-    if pkg_list is None:
-        pkg_list = ["app_common"]
-
     if not dt_fmt:
         dt_fmt = "%Y/%m/%d %H:%M:%S"
 
     http_handler = CustomHTTPHandler(url, dt_fmt=dt_fmt, **kwargs)
     http_handler.setLevel(logging_level)
 
-    # Only remote log the application's messages to avoid noise and
-    # RecursionError because requests sends logging messages:
-    for pkg in pkg_list:
-        logger = getLogger(pkg)
-        logger.addHandler(http_handler)
+    logger = getLogger()
+    logger.addHandler(http_handler)
 
-        try:
-            logger.log(logging_level+10, "Testing new remote handler...")
-            msg = "Remote handler seems to be working normally."
-            logger.debug(msg)
-        except Exception as e:
-            logger.handlers.remove(http_handler)
-            msg = "Failed to issue a log call, probably because of the " \
-                  "remote handler. Removed the remote handler. Error was '{}'."
-            msg = msg.format(e)
-            logger.error(msg)
-        finally:
-            break
+    try:
+        logger.log(logging_level+10, "Testing new remote handler...")
+        msg = "Remote handler seems to be working normally."
+        logger.debug(msg)
+    except Exception as e:
+        logger.handlers.remove(http_handler)
+        msg = "Failed to issue a log call, probably because of the " \
+              "remote handler. Removed the remote handler. Error was '{}'."
+        msg = msg.format(e)
+        logger.error(msg)
 
     return http_handler
 

--- a/app_common/std_lib/logging_utils.py
+++ b/app_common/std_lib/logging_utils.py
@@ -4,13 +4,9 @@ applications.
 import time
 from logging import DEBUG, FileHandler, Formatter, getLogger, Handler, INFO, \
     StreamHandler, WARNING
-from datetime import datetime
 import os
 from os.path import isdir, join
-import requests
-from uuid import uuid4
 
-from app_common.std_lib.os_utils import collect_user_name
 
 
 def initialize_logging(logging_level=WARNING, log_file=None, log_dir=".",
@@ -96,7 +92,7 @@ def initialize_logging(logging_level=WARNING, log_file=None, log_dir=".",
 
 
 def http_logging_handler(url="", pkg_list=None, dt_fmt="", logging_level=INFO,
-                         **kwargs):
+                         handler_klass=CustomHTTPHandler, **kwargs):
     """ Create and add HTTP handler to send logging calls to remote API.
 
     Parameters
@@ -145,56 +141,6 @@ def http_logging_handler(url="", pkg_list=None, dt_fmt="", logging_level=INFO,
         logger.error(msg)
 
     return http_handler
-
-
-class CustomHTTPHandler(Handler):
-    """ Custom HTTPHandler passing the HTTP request using the requests.post
-    method, since it tends to be more stable for REST API end points.
-    """
-    def __init__(self, url, app_name="", start_dt="", dt_fmt="", **adtl_data):
-        """ Initialize the instance with the request URL and all parameters.
-        """
-        super(CustomHTTPHandler, self).__init__()
-        self.url = url
-        self.app_name = app_name
-        self.adtl_data = adtl_data
-        self.start_dt = start_dt
-        self.dt_fmt = dt_fmt
-
-    def emit(self, record):
-        """ Custom implementation of emit using requests.post since it tends to
-        work more easily with REST API end points.
-        """
-        data = self.map_log_record(record)
-        # Build a valid json string with the data to record:
-        data_str = str(data).replace("'", '"')
-        response = requests.post(self.url, data=data_str)
-        return response
-
-    def map_log_record(self, record):
-        """ Custom implementation of mapping the log record into a dict.
-        """
-        # Generate utc datetime since default logging collects local time:
-        utc_datetime = datetime.strftime(datetime.utcnow(), self.dt_fmt)
-        username = collect_user_name()
-        # This log_id should be unique and constant throughout a tool
-        # usage:
-        session_id = self.app_name + ":" + username + ":" + self.start_dt
-        data = {
-            "log_id": str(uuid4()),
-            "session_id": session_id,
-            "app_name": self.app_name,
-            'user': username,
-            "pkg": record.name,
-            'level_no': record.levelno,
-            'line_no': record.lineno,
-            'func_name': record.funcName,
-            'utc_timestamp': utc_datetime,
-            'msg': record.msg
-        }
-        data.update(self.adtl_data)
-
-        return data
 
 
 def add_stream_handler(logging_level=DEBUG):

--- a/app_common/std_lib/remote_logging_handler.py
+++ b/app_common/std_lib/remote_logging_handler.py
@@ -1,0 +1,56 @@
+from logging import Handler
+from datetime import datetime
+import requests
+from uuid import uuid4
+
+from app_common.std_lib.os_utils import collect_user_name
+
+
+class CustomHTTPHandler(Handler):
+    """ Custom HTTPHandler passing the HTTP request using the requests.post
+    method, since it tends to be more stable for REST API end points.
+    """
+    def __init__(self, url, app_name="", start_dt="", dt_fmt="", **adtl_data):
+        """ Initialize the instance with the request URL and all parameters.
+        """
+        super(CustomHTTPHandler, self).__init__()
+        self.url = url
+        self.app_name = app_name
+        self.adtl_data = adtl_data
+        self.start_dt = start_dt
+        self.dt_fmt = dt_fmt
+
+    def emit(self, record):
+        """ Custom implementation of emit using requests.post since it tends to
+        work more easily with REST API end points.
+        """
+        data = self.map_log_record(record)
+        # Build a valid json string with the data to record:
+        data_str = str(data).replace("'", '"')
+        response = requests.post(self.url, data=data_str)
+        return response
+
+    def map_log_record(self, record):
+        """ Custom implementation of mapping the log record into a dict.
+        """
+        # Generate utc datetime since default logging collects local time:
+        utc_datetime = datetime.strftime(datetime.utcnow(), self.dt_fmt)
+        username = collect_user_name()
+        # This log_id should be unique and constant throughout a tool
+        # usage:
+        session_id = self.app_name + ":" + username + ":" + self.start_dt
+        data = {
+            "log_id": str(uuid4()),
+            "session_id": session_id,
+            "app_name": self.app_name,
+            'user': username,
+            "pkg": record.name,
+            'level_no': record.levelno,
+            'line_no': record.lineno,
+            'func_name': record.funcName,
+            'utc_timestamp': utc_datetime,
+            'msg': record.msg
+        }
+        data.update(self.adtl_data)
+
+        return data

--- a/app_common/std_lib/remote_logging_handler.py
+++ b/app_common/std_lib/remote_logging_handler.py
@@ -6,14 +6,14 @@ from uuid import uuid4
 from app_common.std_lib.os_utils import collect_user_name
 
 
-class CustomHTTPHandler(Handler):
+class RequestsHTTPHandler(Handler):
     """ Custom HTTPHandler passing the HTTP request using the requests.post
     method, since it tends to be more stable for REST API end points.
     """
     def __init__(self, url, app_name="", start_dt="", dt_fmt="", **adtl_data):
         """ Initialize the instance with the request URL and all parameters.
         """
-        super(CustomHTTPHandler, self).__init__()
+        super(RequestsHTTPHandler, self).__init__()
         self.url = url
         self.app_name = app_name
         self.adtl_data = adtl_data

--- a/app_common/std_lib/remote_logging_handler.py
+++ b/app_common/std_lib/remote_logging_handler.py
@@ -3,8 +3,6 @@ from datetime import datetime
 import requests
 from uuid import uuid4
 
-from app_common.std_lib.os_utils import collect_user_name
-
 
 class RequestsHTTPHandler(Handler):
     """ Custom HTTPHandler passing the HTTP request using the requests.post

--- a/app_common/std_lib/tests/test_logging_utils.py
+++ b/app_common/std_lib/tests/test_logging_utils.py
@@ -81,6 +81,10 @@ class TestLoggingInitialization(TestCase):
             self.assertIsInstance(root_logger.handlers[1], logging.FileHandler)
             self.assertEqual(root_logger.handlers[1].level, logging.DEBUG)
         finally:
+            # Clean up:
+            file_handler = root_logger.handlers[1]
+            file_handler.flush()
+            file_handler.close()
             os.remove(filename)
 
     def test_initialize_with_httplogging(self):
@@ -94,7 +98,7 @@ class TestLoggingInitialization(TestCase):
         self.assertIsInstance(logger.handlers[0],
                               logging.StreamHandler)
         self.assertIsInstance(logger.handlers[1], RequestsHTTPHandler)
-        self.assertEqual(logger.handlers[1].level, logging.INFO)
+        self.assertEqual(logger.handlers[1].level, logging.WARNING)
 
     def test_httplogging_custom_handler_klass(self):
         self.assert_initial_state()
@@ -105,7 +109,7 @@ class TestLoggingInitialization(TestCase):
         logger = self.root_logger
         self.assertEqual(len(logger.handlers), 2)
         self.assertIsInstance(logger.handlers[1], FooHandler)
-        self.assertEqual(logger.handlers[1].level, logging.INFO)
+        self.assertEqual(logger.handlers[1].level, logging.WARNING)
 
     def test_httplogging_custom_level(self):
         self.assert_initial_state()

--- a/ci/requirements.json
+++ b/ci/requirements.json
@@ -9,6 +9,7 @@
   "pyqt5",
   "pyyaml",
   "qt",
+  "requests",
   "traits",
   "traitsui",
   "scimath",


### PR DESCRIPTION
Add an option to support including a remote logging handler to the `initialize_logging` utility for users who have a HTTP POST service running and capable of receiving logging information for storage, analysis, ... Includes an example Handler.

For it to work, a URL must expose and accept POST requests, and handle the provided data.