### PR TITLE
Feature: switch to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = traitsui
+source = app_common
 omit = */tests/*
 
 [report]

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,5 @@ install:
   - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit; done; fi
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
-  - edm run -- python etstool.py flake8
-
 after_success:
-  - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov
+  - edm run -- python etstool.py flake8

--- a/app_common/std_lib/tests/test_logging_utils.py
+++ b/app_common/std_lib/tests/test_logging_utils.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 import logging
 import os
-from nose.plugins.logcapture import MyMemoryHandler
 
 from app_common.std_lib.logging_utils import RequestsHTTPHandler, \
     initialize_logging
@@ -23,10 +22,16 @@ class TestLoggingInitialization(TestCase):
 
     def assert_initial_state(self):
         root_logger = self.root_logger
-        # By default, if tests run with nose, there is a nose handler:
+        # If tests run with pytest, there are 4 pytest handlers by default:
         if root_logger.handlers:
-            self.assertEqual(len(root_logger.handlers), 1)
-            self.assertIsInstance(root_logger.handlers[0], MyMemoryHandler)
+            from _pytest.logging import _LiveLoggingNullHandler, \
+                LogCaptureHandler, _FileHandler
+
+            self.assertEqual(len(root_logger.handlers), 4)
+            for handler in root_logger.handlers:
+                pytest_handlers = (_LiveLoggingNullHandler, LogCaptureHandler,
+                                   _FileHandler)
+                self.assertIsInstance(handler, pytest_handlers)
         else:
             self.assertEqual(len(root_logger.handlers), 0)
 

--- a/app_common/std_lib/tests/test_time_utils.py
+++ b/app_common/std_lib/tests/test_time_utils.py
@@ -29,7 +29,7 @@ class TestTimedCall(TestCase):
         sleeping_func()
 
     def test_print_info(self):
-        with capture_stdout() as str_io:
+        with capture_stdout(steam_close=False) as str_io:
             @timed_call(report="print")
             def sleeping_func():
                 time.sleep(.2)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,4 @@ test_script:
   - appveyor-run.cmd test %runtime% %toolkits%
 on_success:
   - appveyor-run.cmd flake8 %runtime% %toolkits%
-  - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov
+  # TODO: Upload xml coverage report to coverage service

--- a/ci/dev_requirements.json
+++ b/ci/dev_requirements.json
@@ -1,5 +1,4 @@
 [
-	"coverage",
 	"flake8",
 	"ipython4",
 	"nose",

--- a/ci/pip_requirements.json
+++ b/ci/pip_requirements.json
@@ -1,0 +1,4 @@
+[
+  "pytest",
+  "pytest-cov"
+]

--- a/etstool.py
+++ b/etstool.py
@@ -119,7 +119,7 @@ extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
     'pyqt5': {'pyqt5'},
-    'wx': set("wx"),
+    'wx': {"wx"},
 }
 
 runtime_dependencies = {}

--- a/etstool.py
+++ b/etstool.py
@@ -237,8 +237,10 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
          target, cov):
     """ Run the test suite in a given environment with the specified toolkit.
     """
+    cov_file = ""
+
     parameters = get_parameters(
-        runtime, toolkit, environment, edm_dir=edm_dir,
+        runtime, toolkit, environment, edm_dir=edm_dir, cov_file=cov_file,
         test_pattern=test_pattern, num_slowest=num_slowest, target=target
     )
     environ = environment_vars.get(toolkit, {}).copy()
@@ -247,8 +249,9 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
     if cov:
         commands = [
             "{edm_dir}edm run -e {environment} -- pytest "
-            "--cov-config=.coveragerc --cov={PKG_NAME} "
-            "--durations={num_slowest} {target}",
+            "--cov-config=.coveragerc --durations={num_slowest} "
+            "--cov={PKG_NAME} --cov-report=xml:test_coverage.xml "
+            "--cov-report=html:test_coverage.html --cov-report term {target}",
         ]
     else:
         commands = [
@@ -261,7 +264,6 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
     # that directory, plus coverage has a bug that means a non-local coverage
     # file doesn't get populated correctly.
     click.echo("Running tests in '{environment}'".format(**parameters))
-    #with do_in_tempdir(files=['.coveragerc'], capture_files=['./.coverage*']):
     os.environ.update(environ)
     execute(commands, parameters)
     click.echo('Done test')

--- a/etstool.py
+++ b/etstool.py
@@ -106,7 +106,10 @@ PIP_DEPENDENCIES = "ci/pip_requirements.json"
 dependencies = set(json.load(open(DEPENDENCIES)) +
                    json.load(open(DEV_DEPENDENCIES)))
 
-pip_dependencies = json.load(open(PIP_DEPENDENCIES))
+if os.path.isfile(PIP_DEPENDENCIES):
+    pip_dependencies = json.load(open(PIP_DEPENDENCIES))
+else:
+    pip_dependencies = []
 
 # Additional toolkit-independent dependencies for demo testing
 test_dependencies = set()

--- a/etstool.py
+++ b/etstool.py
@@ -229,13 +229,46 @@ def install(runtime, toolkit, environment, edm_dir, editable):
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 @click.option('--edm-dir', default="")
 @click.option('--environment', default=None)
-@click.option('--cov', default=True)
-@click.option('--test-pattern', default="*")
+@click.option('--cov', default=True, type=bool)
+@click.option('--test-pattern', default="")
 @click.option('--num-slowest', default="0")
 @click.option('--target', default=PKG_NAME)
 def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
          target, cov):
-    """ Run the test suite in a given environment with the specified toolkit.
+    """ Run test suite (& coverage) in test environment for specified toolkit.
+
+    Parameters
+    ----------
+    runtime : str, optional
+        Version of Python runtime, e.g. '3.6'.
+
+    toolkit : str, optional
+        Name of the GUI toolkit to run the tests for, e.g. 'pyqt5'.
+
+    edm_dir : str, optional
+        Path to the edm executable. Useful if the edm executable is not on the
+        PATH environment variable.
+
+    environment : str, optional
+        Name of the environment to use to execute the command. Leave as None to
+        build from the requested runtime and toolkit.
+
+    cov : bool, optional
+        Whether to compute the test coverage. Defaults to True.
+
+    test_pattern : str, optional
+        Pattern of the tests to run. Passed as is to pytest's -m option.
+
+    num_slowest : str, optional
+        Number of slowest tests we want to see times for. Defaults to seeing
+        all test speeds.
+
+    target : str, optional
+        Target package, subpackage, test module, test class or test method to
+        run.
+
+    TODO: figure out how to make the test suite run in parallel (with
+     '-n auto' option). Currently, parallel execution leads to failures.
     """
     cov_file = ""
 
@@ -251,12 +284,13 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
             "{edm_dir}edm run -e {environment} -- pytest "
             "--cov-config=.coveragerc --durations={num_slowest} "
             "--cov={PKG_NAME} --cov-report=xml:test_coverage.xml "
-            "--cov-report=html:test_coverage.html --cov-report term {target}",
+            "--cov-report=html:test_coverage.html --cov-report term "
+            "-m {test_pattern} {target}",
         ]
     else:
         commands = [
             "{edm_dir}edm run -e {environment} -- pytest "
-            "--durations={num_slowest} {target}",
+            "--durations={num_slowest} -m {test_pattern} {target}",
         ]
 
     # We run in a tempdir to avoid accidentally picking up wrong package
@@ -276,6 +310,22 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
 @click.option('--environment', default=None)
 def flake8(runtime, toolkit, edm_dir, environment):
     """ Run flake8 on the source code.
+
+    Parameters
+    ----------
+    runtime : str, optional
+        Version of Python runtime, e.g. '3.6'.
+
+    toolkit : str, optional
+        Name of the GUI toolkit to run the tests for, e.g. 'pyqt5'.
+
+    edm_dir : str, optional
+        Path to the edm executable. Useful if the edm executable is not on the
+        PATH environment variable.
+
+    environment : str, optional
+        Name of the environment to use to execute the command. Leave as None to
+        build from the requested runtime and toolkit.
     """
     parameters = get_parameters(runtime, toolkit, environment, edm_dir=edm_dir)
 
@@ -290,15 +340,31 @@ def flake8(runtime, toolkit, edm_dir, environment):
 @cli.command()
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
+@click.option('--edm-dir', default="")
 @click.option('--environment', default=None)
-def cleanup(runtime, toolkit, environment):
+def cleanup(runtime, toolkit, edm_dir, environment):
     """ Remove a development environment.
 
+    Parameters
+    ----------
+    runtime : str, optional
+        Version of Python runtime, e.g. '3.6'.
+
+    toolkit : str, optional
+        Name of the GUI toolkit to run the tests for, e.g. 'pyqt5'.
+
+    edm_dir : str, optional
+        Path to the edm executable. Useful if the edm executable is not on the
+        PATH environment variable.
+
+    environment : str, optional
+        Name of the environment to use to execute the command. Leave as None to
+        build from the requested runtime and toolkit.
     """
-    parameters = get_parameters(runtime, toolkit, environment)
+    parameters = get_parameters(runtime, toolkit, environment, edm_dir=edm_dir)
     commands = [
-        "edm run -e {environment} -- python setup.py clean",
-        "edm environments remove {environment} --purge -y"]
+        "{edm_dir}edm run -e {environment} -- python setup.py clean",
+        "{edm_dir}edm environments remove {environment} --purge -y"]
     click.echo("Cleaning up environment '{environment}'".format(**parameters))
     execute(commands, parameters)
     click.echo('Done cleanup')
@@ -308,8 +374,15 @@ def cleanup(runtime, toolkit, environment):
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 def test_clean(runtime, toolkit):
-    """ Run tests in a clean environment, cleaning up afterwards
+    """ Run tests in a clean environment, cleaning up afterwards.
 
+    Parameters
+    ----------
+    runtime : str, optional
+        Version of Python runtime, e.g. '3.6'.
+
+    toolkit : str, optional
+        Name of the GUI toolkit to run the tests for, e.g. 'pyqt5'.
     """
     args = ['--toolkit={}'.format(toolkit), '--runtime={}'.format(runtime)]
     try:
@@ -322,13 +395,30 @@ def test_clean(runtime, toolkit):
 @cli.command()
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
+@click.option('--edm-dir', default="")
 @click.option('--environment', default=None)
-def update(runtime, toolkit, environment):
+def update(runtime, toolkit, edm_dir, environment):
     """ Update/re-install package into environment.
+
+    Parameters
+    ----------
+    runtime : str, optional
+        Version of Python runtime, e.g. '3.6'.
+
+    toolkit : str, optional
+        Name of the GUI toolkit to run the tests for, e.g. 'pyqt5'.
+
+    edm_dir : str, optional
+        Path to the edm executable. Useful if the edm executable is not on the
+        PATH environment variable.
+
+    environment : str, optional
+        Name of the environment to use to execute the command. Leave as None to
+        build from the requested runtime and toolkit.
     """
-    parameters = get_parameters(runtime, toolkit, environment)
+    parameters = get_parameters(runtime, toolkit, environment, edm_dir=edm_dir)
     commands = [
-        "edm run -e {environment} -- python setup.py install"]
+        "{edm_dir}edm run -e {environment} -- python setup.py install"]
     click.echo("Re-installing in  '{environment}'".format(**parameters))
     execute(commands, parameters)
     click.echo('Done update')
@@ -337,14 +427,31 @@ def update(runtime, toolkit, environment):
 @cli.command()
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
+@click.option('--edm-dir', default="")
 @click.option('--environment', default=None)
-def docs(runtime, toolkit, environment):
+def docs(runtime, toolkit, edm_dir, environment):
     """ Auto-generate documentation.
+
+    Parameters
+    ----------
+    runtime : str, optional
+        Version of Python runtime, e.g. '3.6'.
+
+    toolkit : str, optional
+        Name of the GUI toolkit to run the tests for, e.g. 'pyqt5'.
+
+    edm_dir : str, optional
+        Path to the edm executable. Useful if the edm executable is not on the
+        PATH environment variable.
+
+    environment : str, optional
+        Name of the environment to use to execute the command. Leave as None to
+        build from the requested runtime and toolkit.
     """
-    parameters = get_parameters(runtime, toolkit, environment)
+    parameters = get_parameters(runtime, toolkit, environment, edm_dir=edm_dir)
     packages = ' '.join(doc_dependencies)
     commands = [
-        "edm install -y -e {environment} " + packages,
+        "{edm_dir}edm install -y -e {environment} " + packages,
     ]
     click.echo("Installing documentation tools in  '{environment}'".format(
         **parameters))
@@ -353,7 +460,7 @@ def docs(runtime, toolkit, environment):
 
     os.chdir('docs')
     commands = [
-        "edm run -e {environment} -- make html",
+        "{edm_dir}edm run -e {environment} -- make html",
     ]
     click.echo("Building documentation in  '{environment}'".format(**parameters))
     try:
@@ -366,7 +473,6 @@ def docs(runtime, toolkit, environment):
 @cli.command()
 def test_all():
     """ Run test_clean across all supported environment combinations.
-
     """
     failed_command = False
     for runtime, toolkits in supported_combinations.items():

--- a/etstool.py
+++ b/etstool.py
@@ -111,9 +111,10 @@ if os.path.isfile(PIP_DEPENDENCIES):
 else:
     pip_dependencies = []
 
-# Additional toolkit-independent dependencies for demo testing
+# Additional toolkit-independent dependencies
 test_dependencies = set()
 
+# Additional toolkit-dependent dependencies
 extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),

--- a/etstool.py
+++ b/etstool.py
@@ -101,11 +101,12 @@ DEFAULT_TOOLKIT = 'pyqt5'
 
 DEPENDENCIES = "ci/requirements.json"
 DEV_DEPENDENCIES = "ci/dev_requirements.json"
+PIP_DEPENDENCIES = "ci/pip_requirements.json"
 
 dependencies = set(json.load(open(DEPENDENCIES)) +
                    json.load(open(DEV_DEPENDENCIES)))
 
-source_dependencies = {}
+pip_dependencies = json.load(open(PIP_DEPENDENCIES))
 
 # Additional toolkit-independent dependencies for demo testing
 test_dependencies = set()
@@ -164,7 +165,7 @@ def install(runtime, toolkit, environment, edm_dir, editable):
         "--version={runtime}",
         "{edm_dir}edm install -y -e {environment} " + packages,
         "{edm_dir}edm run -e {environment} -- python setup.py clean --all",
-        "{edm_dir}edm run -e {environment} -- python setup.py install",
+        "{edm_dir}edm run -e {environment} -- pip install -e .",
     ]
 
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
@@ -186,16 +187,10 @@ def install(runtime, toolkit, environment, edm_dir, editable):
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
 
-    if source_dependencies:
-        cmd_fmt = "{edm_dir}edm plumbing remove-package --environment {environment} " \
-                  "--force "
-        commands = [cmd_fmt+dependency
-                    for dependency in source_dependencies.keys()]
-        execute(commands, parameters)
-        source_pkgs = source_dependencies.values()
+    if pip_dependencies:
         commands = [
-            "python -m pip install {pkg} --no-deps".format(pkg=pkg)
-            for pkg in source_pkgs
+            "python -m pip install {pkg}".format(pkg=pkg)
+            for pkg in pip_dependencies
         ]
         commands = ["{edm_dir}edm run -e {environment} -- " + command
                     for command in commands]
@@ -209,36 +204,41 @@ def install(runtime, toolkit, environment, edm_dir, editable):
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 @click.option('--edm-dir', default="")
 @click.option('--environment', default=None)
-def test(runtime, toolkit, edm_dir, environment):
+@click.option('--cov', default=True)
+@click.option('--test-pattern', default="*")
+@click.option('--num-slowest', default="0")
+@click.option('--target', default=PKG_NAME)
+def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
+         target, cov):
     """ Run the test suite in a given environment with the specified toolkit.
-
     """
-    parameters = get_parameters(runtime, toolkit, environment)
-    parameters["edm_dir"] = edm_dir
-
+    parameters = get_parameters(
+        runtime, toolkit, environment, edm_dir=edm_dir,
+        test_pattern=test_pattern, num_slowest=num_slowest, target=target
+    )
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
 
-    if toolkit == "wx":
-        environ["EXCLUDE_TESTS"] = "qt"
-    elif toolkit in {"pyqt", "pyqt5", "pyside", "pyside2"}:
-        environ["EXCLUDE_TESTS"] = "wx"
+    if cov:
+        commands = [
+            "{edm_dir}edm run -e {environment} -- pytest "
+            "--cov-config=.coveragerc --cov={PKG_NAME} "
+            "--durations={num_slowest} {target}",
+        ]
     else:
-        environ["EXCLUDE_TESTS"] = "(wx|qt)"
-
-    commands = [
-        "{edm_dir}edm run -e {environment} -- coverage run -p -m unittest "
-        "discover -v " + PKG_NAME,
-    ]
+        commands = [
+            "{edm_dir}edm run -e {environment} -- pytest "
+            "--durations={num_slowest} {target}",
+        ]
 
     # We run in a tempdir to avoid accidentally picking up wrong package
     # code from a local dir. We need to ensure a good .coveragerc is in
     # that directory, plus coverage has a bug that means a non-local coverage
     # file doesn't get populated correctly.
     click.echo("Running tests in '{environment}'".format(**parameters))
-    with do_in_tempdir(files=['.coveragerc'], capture_files=['./.coverage*']):
-        os.environ.update(environ)
-        execute(commands, parameters)
+    #with do_in_tempdir(files=['.coveragerc'], capture_files=['./.coverage*']):
+    os.environ.update(environ)
+    execute(commands, parameters)
     click.echo('Done test')
 
 
@@ -250,11 +250,10 @@ def test(runtime, toolkit, edm_dir, environment):
 def flake8(runtime, toolkit, edm_dir, environment):
     """ Run flake8 on the source code.
     """
-    parameters = get_parameters(runtime, toolkit, environment)
-    parameters["edm_dir"] = edm_dir
+    parameters = get_parameters(runtime, toolkit, environment, edm_dir=edm_dir)
 
     commands = [
-        "{edm_dir}edm run -e {environment} flake8 setup.py " + PKG_NAME,
+        "{edm_dir}edm run -e {environment} flake8 setup.py {PKG_NAME}",
     ]
 
     execute(commands, parameters)
@@ -298,8 +297,7 @@ def test_clean(runtime, toolkit):
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 @click.option('--environment', default=None)
 def update(runtime, toolkit, environment):
-    """ Update/Reinstall package into environment.
-
+    """ Update/re-install package into environment.
     """
     parameters = get_parameters(runtime, toolkit, environment)
     commands = [
@@ -314,8 +312,7 @@ def update(runtime, toolkit, environment):
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 @click.option('--environment', default=None)
 def docs(runtime, toolkit, environment):
-    """ Autogenerate documentation
-
+    """ Auto-generate documentation.
     """
     parameters = get_parameters(runtime, toolkit, environment)
     packages = ' '.join(doc_dependencies)
@@ -363,15 +360,22 @@ def test_all():
 # Utility routines
 # ----------------------------------------------------------------------------
 
-def get_parameters(runtime, toolkit, environment):
-    """ Set up parameters dictionary for format() substitution """
-    parameters = {'runtime': runtime, 'toolkit': toolkit, 'environment': environment}
+def get_parameters(runtime, toolkit, environment, **adtl_params):
+    """ Set up parameters dictionary for format() substitution.
+    """
+    parameters = {'runtime': runtime, 'toolkit': toolkit,
+                  'environment': environment, "PKG_NAME": PKG_NAME}
+    parameters.update(adtl_params)
+
     if toolkit not in supported_combinations[runtime]:
         msg = ("Python {runtime} and toolkit {toolkit} not supported by " +
                "test environments")
         raise RuntimeError(msg.format(**parameters))
+
     if environment is None:
-        parameters['environment'] = PKG_NAME + '-test-{runtime}-{toolkit}'.format(**parameters)
+        env_pattern = PKG_NAME + '-test-{toolkit}-py{runtime}'
+        parameters['environment'] = env_pattern.format(**parameters)
+        parameters['environment'] = parameters['environment'].replace(".", "")
     return parameters
 
 


### PR DESCRIPTION
Switch test runner from unittest to pytest. This move adds 
- the ability to see what time each test takes,  
- generates an XML file that codecov services can consume.
- pytest is less finicky than unittest for finding tests. Might avoid missing tests in the future.