### PR TITLE
Remove pyside2 and wx from supported toolkits

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -123,6 +123,7 @@ extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
     'pyqt5': {'pyqt5'},
+    # XXX once wx is available in EDM, we will want it here
     'wx': set(),
 }
 

--- a/etstool.py
+++ b/etstool.py
@@ -90,7 +90,7 @@ import click
 PKG_NAME = "app_common"
 
 supported_combinations = {
-    '3.6': {'pyside2', 'pyqt5', "wx"},
+    '3.6': {'pyqt5'},
 }
 
 # Default Python version to use in the commands below if none is specified.
@@ -123,7 +123,7 @@ extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
     'pyqt5': {'pyqt5'},
-    'wx': {"wx"},
+    'wx': set(),
 }
 
 runtime_dependencies = {}
@@ -136,6 +136,7 @@ doc_dependencies = {
 environment_vars = {
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
     'pyqt5': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt5"},
+    'wx': {"ETS_TOOLKIT": "wx"},
 }
 
 
@@ -178,10 +179,18 @@ def install(runtime, toolkit, environment, edm_dir, editable):
 
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
     if toolkit == 'pyside2':
+        # Remove the default toolkit from dependency
+        commands.append(
+            "{edm_dir}edm remove -y -e {environment} pyqt5"
+        )
         commands.append(
             "{edm_dir}edm run -e {environment} -- pip install pyside2==5.11"
         )
     elif toolkit == 'wx':
+        commands.append(
+            "{edm_dir}edm remove -y -e {environment} pyqt5 qt"
+        )
+
         if sys.platform != 'linux':
             commands.append(
                 "{edm_dir}edm run -e {environment} -- pip install wxPython"


### PR DESCRIPTION
Still, improve the code for them for hypothetical future support. This fixes the `test-all` command of `etstool.py` script.

Oddly enough, AppVeyor jobs are now starting to pass even though they used to exhibit the following failure (for example [here](https://ci.appveyor.com/project/jonathanrocher/app-common/builds/35749617)):
```
================================== FAILURES ===================================
________________ TestHDFTSArrayCache.test_cleanup_by_last_used ________________
self = <app_common.apptools.cache.tests.test_size_limited_hdf_caches.TestHDFTSArrayCache testMethod=test_cleanup_by_last_used>
 def test_cleanup_by_last_used(self):
 self.cache.num_key_limit = 2
 self.cache.oldest_by = LAST_USED_INDEX_COL
 self.assert_key_in_cache(self.key1)
 self.cache.set_value(self.key2, self.value)
 self.assert_key_in_cache(self.key2)
 self.cache.get_value(self.key1)
 self.cache.set_value(self.key3, self.value)
 self.assert_key_in_cache(self.key3)
> self.assert_key_in_cache(self.key1)
app_common\apptools\cache\base_test_classes.py:538: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
app_common\apptools\cache\tests\test_size_limited_hdf_caches.py:123: in assert_key_in_cache
 self.assertIn(key, self.cache)
E AssertionError: 'abc/def' not found in <app_common.apptools.cache.size_limited_hdf_caches.SizeLimitedHDFSingleArrayCache object at 0x000001610946E308>
------------------------------ Captured log call ------------------------------
WARNING app_common.apptools.cache.size_limited_hdf_caches:size_limited_hdf_caches.py:35 No max number of keys was specified. If no limit is needed, it is recommended to use a regular HDF implementation, or a regular timestamped implementation.
```