### PR TITLE
Add debug mode to is_has_traits_almost_equal.

### DIFF
--- a/app_common/apptools/io/assertion_utils.py
+++ b/app_common/apptools/io/assertion_utils.py
@@ -15,7 +15,7 @@ from app_common.apptools.io.deserializer import deserialize
 
 
 def assert_roundtrip_identical(obj, serial_func=None, deserial_func=None,
-                               ignore=(), eps=1e-9):
+                               **kwargs):
     """ Serialize and deserialize an object and assert that the resulting
     object is identical to the input object.
 
@@ -31,12 +31,8 @@ def assert_roundtrip_identical(obj, serial_func=None, deserial_func=None,
         Function to deserialize data into an object. Should return a collection
         where the deserialized object is the first element.
 
-    ignore : collection
-        List of attribute names to ignore when checking that the roundtrip gave
-        an identical object.
-
-    eps : float
-        Precision beyond which floating point values are considered different.
+    kwargs : dict
+        Additional keyword arguments passed to `is_has_traits_almost_equal`.
 
     Returns
     -------
@@ -57,14 +53,14 @@ def assert_roundtrip_identical(obj, serial_func=None, deserial_func=None,
                                    array_collection=array_collection)[0]
 
     if isinstance(obj, HasTraits):
-        assert_has_traits_almost_equal(obj, new_object, ignore=ignore, eps=eps)
+        assert_has_traits_almost_equal(obj, new_object, **kwargs)
     else:
-        assert_values_almost_equal(obj, new_object, ignore=ignore, eps=eps)
+        assert_values_almost_equal(obj, new_object, **kwargs)
     return new_object
 
 
 def assert_file_roundtrip_identical(obj, save_func=None, load_func=None,
-                                    ignore=(), eps=1e-9, target_dir=None):
+                                    target_dir=None, **kwargs):
     """ Serialize and deserialize an object and assert that the resulting
     object is identical to the input object.
 
@@ -78,12 +74,8 @@ def assert_file_roundtrip_identical(obj, save_func=None, load_func=None,
         Function to load the object from file. It should return a collection
         where the deserialized object is the first element.
 
-    ignore : collection
-        List of attribute names to ignore when checking that the roundtrip gave
-        an identical object.
-
-    eps : float
-        Precision beyond which floating point values are considered different.
+    kwargs : dict
+        Additional keyword arguments passed to `is_has_traits_almost_equal`.
 
     Returns
     -------
@@ -105,7 +97,6 @@ def assert_file_roundtrip_identical(obj, save_func=None, load_func=None,
             new_object = load_func(fname)[0]
 
         if isinstance(obj, HasTraits):
-            assert_has_traits_almost_equal(obj, new_object, ignore=ignore,
-                                           eps=eps)
+            assert_has_traits_almost_equal(obj, new_object, **kwargs)
         else:
-            assert_values_almost_equal(obj, new_object, ignore=ignore, eps=eps)
+            assert_values_almost_equal(obj, new_object, **kwargs)

--- a/app_common/traits/assertion_utils.py
+++ b/app_common/traits/assertion_utils.py
@@ -19,7 +19,7 @@ def assert_has_traits_almost_equal(obj1, obj2, **kwargs):
         Additional keyword arguments passed to `is_has_traits_almost_equal`.
     """
     is_equal, msg = is_has_traits_almost_equal(obj1, obj2, **kwargs)
-    error_msg = "HasTraits objects are not almost equal: {}".format(msg)
+    error_msg = f"HasTraits objects are not almost equal: {msg}"
     assert_true(is_equal, error_msg)
 
 
@@ -36,7 +36,7 @@ def assert_has_traits_not_almost_equal(obj1, obj2, **kwargs):
 
     """
     is_equal, msg = is_has_traits_almost_equal(obj1, obj2, **kwargs)
-    error_msg = "HasTraits objects are not almost equal: {}".format(msg)
+    error_msg = f"HasTraits objects are unexpectedly almost equal: {msg}"
     assert_false(is_equal, error_msg)
 
 
@@ -54,7 +54,7 @@ def assert_values_almost_equal(val1, val2, **kwargs):
         Additional keyword arguments passed to `is_val_almost_equal`.
     """
     is_equal, msg = is_val_almost_equal(val1, val2, **kwargs)
-    assert_true(is_equal, "Values are not almost equal: {}".format(msg))
+    assert_true(is_equal, f"Values are not almost equal: {msg}")
 
 
 def assert_values_not_almost_equal(val1, val2, **kwargs):
@@ -71,4 +71,4 @@ def assert_values_not_almost_equal(val1, val2, **kwargs):
         Additional keyword arguments passed to `is_val_almost_equal`.
     """
     is_equal, msg = is_val_almost_equal(val1, val2, **kwargs)
-    assert_false(is_equal, "Values are not almost equal: {}".format(msg))
+    assert_false(is_equal, f"Values are unexpectedly almost equal: {msg}")

--- a/app_common/traits/assertion_utils.py
+++ b/app_common/traits/assertion_utils.py
@@ -7,8 +7,7 @@ from app_common.traits.has_traits_utils import is_has_traits_almost_equal, \
     is_val_almost_equal
 
 
-def assert_has_traits_almost_equal(obj1, obj2, eps=1e-9, ignore=(),
-                                   check_type=True):
+def assert_has_traits_almost_equal(obj1, obj2, **kwargs):
     """ Compare 2 HasTraits objects and assert they are almost equal.
 
     Parameters
@@ -16,26 +15,15 @@ def assert_has_traits_almost_equal(obj1, obj2, eps=1e-9, ignore=(),
     obj1, obj2 : HasTraits instances
         HasTraits class instances to compare.
 
-    eps : float
-        Precision beyond which floating point values are considered different.
-
-    ignore : sequence of str
-        List of attribute names to skip from checks. These are passed
-        recursively to children and must match the object's attribute name of
-        one of its children attribute name.
-
-    check_type : bool
-        Check whether the 2 objects have the same type? True by default.
+    kwargs : dict
+        Additional keyword arguments passed to `is_has_traits_almost_equal`.
     """
-    is_equal, msg = is_has_traits_almost_equal(
-        obj1, obj2, eps=eps, ignore=ignore, check_type=check_type
-    )
+    is_equal, msg = is_has_traits_almost_equal(obj1, obj2, **kwargs)
     error_msg = "HasTraits objects are not almost equal: {}".format(msg)
     assert_true(is_equal, error_msg)
 
 
-def assert_has_traits_not_almost_equal(obj1, obj2, eps=1e-9, ignore=(),
-                                       check_type=True):
+def assert_has_traits_not_almost_equal(obj1, obj2, **kwargs):
     """ Compare 2 HasTraits objects and assert they are not almost equal.
 
     Parameters
@@ -43,25 +31,16 @@ def assert_has_traits_not_almost_equal(obj1, obj2, eps=1e-9, ignore=(),
     obj1, obj2 : HasTraits instances
         HasTraits class instances to compare.
 
-    eps : float
-        Precision beyond which floating point values are considered different.
+    kwargs : dict
+        Additional keyword arguments passed to `is_has_traits_almost_equal`.
 
-    ignore : sequence of str
-        List of attribute names to skip from checks. These are passed
-        recursively to children and must match the object's attribute name of
-        one of its children attribute name.
-
-    check_type : bool
-        Check whether the 2 objects have the same type? True by default.
     """
-    is_equal, msg = is_has_traits_almost_equal(
-        obj1, obj2, eps=eps, ignore=ignore, check_type=check_type
-    )
+    is_equal, msg = is_has_traits_almost_equal(obj1, obj2, **kwargs)
     error_msg = "HasTraits objects are not almost equal: {}".format(msg)
     assert_false(is_equal, error_msg)
 
 
-def assert_values_almost_equal(val1, val2, eps=1e-9, ignore=()):
+def assert_values_almost_equal(val1, val2, **kwargs):
     """ Compare 2 objects containing HasTraits and assert they are not
     almost equal.
 
@@ -71,22 +50,14 @@ def assert_values_almost_equal(val1, val2, eps=1e-9, ignore=()):
         Non-HasTraits values to compare, typically attributes of a
         HasTraits class.
 
-    attr_name : None or str [OPTIONAL]
-       Name of the attribute that these values are pulled from.
-
-    eps : float
-        Precision beyond which floating point values are considered different.
-
-    ignore : sequence of str
-        List of attribute names to skip from comparisons of objects. These are
-        passed recursively to elements of the values being compared and their
-        children.
+    kwargs : dict
+        Additional keyword arguments passed to `is_val_almost_equal`.
     """
-    is_equal, msg = is_val_almost_equal(val1, val2, eps=eps, ignore=ignore)
+    is_equal, msg = is_val_almost_equal(val1, val2, **kwargs)
     assert_true(is_equal, "Values are not almost equal: {}".format(msg))
 
 
-def assert_values_not_almost_equal(val1, val2, eps=1e-9, ignore=()):
+def assert_values_not_almost_equal(val1, val2, **kwargs):
     """ Compare 2 objects containing HasTraits and assert they are not
     almost equal.
 
@@ -96,16 +67,8 @@ def assert_values_not_almost_equal(val1, val2, eps=1e-9, ignore=()):
         Non-HasTraits values to compare, typically attributes of a
         HasTraits class.
 
-    attr_name : None or str [OPTIONAL]
-       Name of the attribute that these values are pulled from.
-
-    eps : float
-        Precision beyond which floating point values are considered different.
-
-    ignore : sequence of str
-        List of attribute names to skip from comparisons of objects. These are
-        passed recursively to elements of the values being compared and their
-        children.
+    kwargs : dict
+        Additional keyword arguments passed to `is_val_almost_equal`.
     """
-    is_equal, msg = is_val_almost_equal(val1, val2, eps=eps, ignore=ignore)
+    is_equal, msg = is_val_almost_equal(val1, val2, **kwargs)
     assert_false(is_equal, "Values are not almost equal: {}".format(msg))

--- a/app_common/traits/has_traits_utils.py
+++ b/app_common/traits/has_traits_utils.py
@@ -52,7 +52,8 @@ def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
         Whether to check the dtypes of the numpy array attributes.
 
     debug : bool
-        Whether to print attribute paths
+        Whether to print attribute paths during usage. Useful if the function
+        raises an exception, to track what attribute led to that exception.
     """
     if not isinstance(obj1, HasTraits):
         msg = "First arg ({}) not a HasTraits class: {}"

--- a/app_common/traits/has_traits_utils.py
+++ b/app_common/traits/has_traits_utils.py
@@ -24,7 +24,8 @@ IGNORE_TYPES = (BuiltinFunctionType, BuiltinMethodType, FunctionType,
 
 
 def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
-                               check_type=True, check_dtype=False):
+                               check_type=True, check_dtype=False,
+                               debug=False):
     """ Test if 2 traits objects are almost equal up to a certain precision.
 
     Parameters
@@ -46,6 +47,12 @@ def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
 
     check_type : bool
         Check whether the 2 objects have the same type? True by default.
+
+    check_dtype : bool
+        Whether to check the dtypes of the numpy array attributes.
+
+    debug : bool
+        Whether to print attribute paths
     """
     if not isinstance(obj1, HasTraits):
         msg = "First arg ({}) not a HasTraits class: {}"
@@ -65,7 +72,8 @@ def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
 
     obj1_traits = set(obj1.trait_names())
     obj2_traits = set(obj2.trait_names())
-    # Make sure the 2 objects don't differ by more than Traits cache attributes
+    # Make sure the 2 objects don't differ by more than the Traits cache
+    # attributes
     for trait_name in obj1_traits ^ obj2_traits:
         if not trait_name.startswith(TRAITS_PROPERTY_CACHE_PREFIX) and \
                         trait_name not in trait_names_to_ignore:
@@ -88,6 +96,10 @@ def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
             trait_path = attr_name + "." + trait
         else:
             trait_path = trait
+
+        if debug:
+            print(f"Comparing objects' {trait_path} attribute.")
+
         if isinstance(val1, HasTraits):
             equal, msg = is_has_traits_almost_equal(val1, val2, trait_path,
                                                     eps=eps, ignore=ignore)
@@ -121,6 +133,9 @@ def is_val_almost_equal(val1, val2, attr_name="", check_dtype=False, eps=1e-9,
         List of attribute names to skip from comparisons of objects. These are
         passed recursively to elements of the values being compared and their
         children.
+
+    check_dtype : bool
+        Whether to check the dtypes if the values are numpy arrays.
     """
     if attr_name is None:
         if hasattr(val1, "name"):

--- a/app_common/traits/has_traits_utils.py
+++ b/app_common/traits/has_traits_utils.py
@@ -52,8 +52,8 @@ def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
         Whether to check the dtypes of the numpy array attributes.
 
     debug : bool
-        Whether to print attribute paths during usage. Useful if the function
-        raises an exception, to track what attribute led to that exception.
+        Whether to print attribute paths during usage. Useful to watch the
+        execution of the comparison, for debugging or timing purposes.
     """
     if not isinstance(obj1, HasTraits):
         msg = "First arg ({}) not a HasTraits class: {}"
@@ -102,12 +102,14 @@ def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
             print(f"Comparing objects' {trait_path} attribute.")
 
         if isinstance(val1, HasTraits):
-            equal, msg = is_has_traits_almost_equal(val1, val2, trait_path,
-                                                    eps=eps, ignore=ignore)
+            equal, msg = is_has_traits_almost_equal(
+                val1, val2, trait_path, eps=eps, ignore=ignore, debug=debug
+            )
         else:
-            equal, msg = is_val_almost_equal(val1, val2, trait_path, eps=eps,
-                                             check_dtype=check_dtype,
-                                             ignore=ignore)
+            equal, msg = is_val_almost_equal(
+                val1, val2, trait_path, eps=eps, check_dtype=check_dtype,
+                ignore=ignore, debug=debug
+            )
         if not equal:
             return False, msg
 
@@ -115,7 +117,7 @@ def is_has_traits_almost_equal(obj1, obj2, attr_name="", eps=1e-9, ignore=(),
 
 
 def is_val_almost_equal(val1, val2, attr_name="", check_dtype=False, eps=1e-9,
-                        ignore=()):
+                        ignore=(), debug=False):
     """ Test if 2 values are almost equal up to a certain precision.
 
     Parameters
@@ -137,6 +139,10 @@ def is_val_almost_equal(val1, val2, attr_name="", check_dtype=False, eps=1e-9,
 
     check_dtype : bool
         Whether to check the dtypes if the values are numpy arrays.
+
+    debug : bool
+        Whether to print attribute paths during usage. Useful to watch the
+        execution of the comparison, for debugging or timing purposes.
     """
     if attr_name is None:
         if hasattr(val1, "name"):
@@ -200,7 +206,8 @@ def is_val_almost_equal(val1, val2, attr_name="", check_dtype=False, eps=1e-9,
             subattr_name = "{}[{}]".format(attr_name, i)
             if isinstance(el1, HasTraits):
                 equal, msg = is_has_traits_almost_equal(
-                    el1, el2, attr_name=subattr_name, eps=eps, ignore=ignore
+                    el1, el2, attr_name=subattr_name, eps=eps, ignore=ignore,
+                    debug=debug
                 )
                 if not equal:
                     return False, msg
@@ -219,7 +226,8 @@ def is_val_almost_equal(val1, val2, attr_name="", check_dtype=False, eps=1e-9,
             val = "{}[{}]".format(attr_name, key)
             if isinstance(el1, HasTraits):
                 equal, msg = is_has_traits_almost_equal(
-                    el1, el2, attr_name=val, eps=eps, ignore=ignore
+                    el1, el2, attr_name=val, eps=eps, ignore=ignore,
+                    debug=debug
                 )
                 if not equal:
                     return False, msg


### PR DESCRIPTION
- Add new `debug` keyword argument. Only useful when an exception is raised by the code, to understand what triggered it. In normal usage, the equality failure will also report what attribute path failed equality.
- General code improvements.