### PR TITLE
Make scimath a soft dependency.

### DIFF
--- a/app_common/apptools/assertion_utils.py
+++ b/app_common/apptools/assertion_utils.py
@@ -1,10 +1,6 @@
 from nose.tools import assert_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
 
-from scimath.units.api import UnitArray, UnitScalar
-from app_common.scimath.assertion_utils import assert_unit_array_almost_equal,\
-    assert_unit_scalar_almost_equal
-
 
 def assert_frame_not_equal(*args, **kwargs):
     """ Not implemented in pandas."""
@@ -31,8 +27,13 @@ def assert_series_not_equal(*args, **kwargs):
 
 
 def flexible_assert_equal(x1, x2, **kw):
-    """ Flexible assertion equality
+    """ Flexible assertion equality, including support for scimath objects.
     """
+    from scimath.units.api import UnitArray, UnitScalar
+    from app_common.scimath.assertion_utils import \
+        assert_unit_array_almost_equal, \
+        assert_unit_scalar_almost_equal
+
     if isinstance(x1, UnitArray):
         assert_unit_array_almost_equal(x1, x2, **kw)
     elif isinstance(x1, UnitScalar):


### PR DESCRIPTION
Protect `scimath` imports into the functions that need them in the assertion utilities.