### PR TITLE
Improve serialization base classes.

### DIFF
--- a/app_common/apptools/io/deserializer.py
+++ b/app_common/apptools/io/deserializer.py
@@ -214,7 +214,7 @@ class deSerializer(HasStrictTraits):
         return instance
 
 
-class dataElementDeSerializer(deSerializer):
+class simpleObjDeSerializer(deSerializer):
 
     klass = Type
 
@@ -222,6 +222,8 @@ class dataElementDeSerializer(deSerializer):
         instance = self.klass(**constructor_data['kwargs'])
         return instance
 
+
+class dataElementDeSerializer(simpleObjDeSerializer):
     def _klass_default(self):
         from app_common.model_tools.data_element import DataElement
         return DataElement

--- a/app_common/apptools/io/serializer.py
+++ b/app_common/apptools/io/serializer.py
@@ -159,14 +159,20 @@ class Serializer(HasStrictTraits):
         return serializer
 
 
-class DataElement_Serializer(Serializer):
+class SimpleObj_Serializer(Serializer):
+    """ Base Serializer for keyword arg only constructors, such as most
+    HasTraits classes.
+    """
     def get_serial_data(self, obj):
-        # Skip data part: almost every HasTraits class gets created without
-        # positional args
         serial_data = self.get_serial_data_base(obj)
         serial_data.update(self.get_instance_data(obj))
         return serial_data
 
+
+class DataElement_Serializer(SimpleObj_Serializer):
+    """ Base Serializer for keyword arg only constructors, such as most
+        HasTraits classes.
+    """
     def attr_names_to_serialize(self, obj):
         return ['name', 'uuid', 'editable']
 

--- a/app_common/data_tools/data_filter.py
+++ b/app_common/data_tools/data_filter.py
@@ -7,7 +7,7 @@ DEFAULT_MAX_ELEMENT_TO_FILTER = 500
 
 
 class DataFilter(DataElement):
-    """ Description of a way to filter, randomize, truncate, sort, groupby a DF
+    """ Description of how to filter, randomize, truncate, sort, groupby a DF.
 
     Note that not all these operations are commutative, so they should be
     applied in the order specified by _operation_order.


### PR DESCRIPTION
- Create a `SimpleObj_Serializer` and `simpleObjDeSerializer` base classes to simplify subclassing for general classes that don't derive from the `DataElement` class.
- Unrelated fly-by docstring tweak.