### PR TITLE
Add new view to edit dictionaries.

### DIFF
--- a/app_common/traitsui/dict_editors.py
+++ b/app_common/traitsui/dict_editors.py
@@ -36,7 +36,16 @@ class DictValueEditor(HasStrictTraits):
 
     show_title_in_view = Bool
 
-    def __init__(self, **traits):
+    def __init__(self, *args, **traits):
+        if args:
+            if len(args) != 1:
+                msg = "A DictValueEditor should be created with 1 " \
+                      "positional argument at the most, providing the " \
+                      "target_dict."
+                raise ValueError(msg)
+            else:
+                traits["target_dict"] = args[0]
+
         super(DictValueEditor, self).__init__(**traits)
         if not self.target_dict:
             msg = "A target dict to edit is needed to be able to edit it."

--- a/app_common/traitsui/dict_editors.py
+++ b/app_common/traitsui/dict_editors.py
@@ -94,7 +94,9 @@ class DictValueEditor(HasStrictTraits):
 if __name__ == "__main__":
     from traits.api import Range
 
-    value_to_trait = lambda value: Range(low=0, high=1, value=value)
+    def value_to_trait(value):
+        return Range(low=0, high=1, value=value)
+
     editor = DictValueEditor(target_dict={"a": 1, "b c": 0.5},
                              value_to_trait=value_to_trait,
                              title="Dict editor", show_title_in_view=True)

--- a/app_common/traitsui/dict_editors.py
+++ b/app_common/traitsui/dict_editors.py
@@ -18,22 +18,31 @@ class DictValueEditor(HasStrictTraits):
     returning Item attributes such as `label`, `readonly`, `editor`, ... By
     default, only the label is set to the dictionary key.
     """
+    #: Dictionary that will be edited
     target_dict = Dict
 
+    #: Dict mapping the trait name to the original key
     _trait_map = Dict
 
+    #: Dict mapping the original key to the created trait name
     _key_map = Dict
 
-    view_klass = Callable
+    #: View class
+    view_klass = Callable(View)
 
-    key_to_trait = Callable
+    #: Function to sanitize the keys to define a trait
+    key_to_trait = Callable(sanitize_string)
 
+    #: Function to convert a value to a (typed) trait
     value_to_trait = Callable(Float)
 
+    #: Function to set Item attributes for a given key
     item_kwargs = Callable(lambda key: {"label": key})
 
+    #: Title of the created window (and potentially displayed )
     title = Str
 
+    #: Whether to display the title inside the UI panel
     show_title_in_view = Bool
 
     def __init__(self, *args, **traits):
@@ -83,12 +92,6 @@ class DictValueEditor(HasStrictTraits):
         trait_changes = {self._key_map[key]: value
                          for key, value in kwargs.items()}
         self.trait_set(**trait_changes)
-
-    def _key_to_trait_default(self):
-        return sanitize_string
-
-    def _view_klass_default(self):
-        return View
 
 
 if __name__ == "__main__":

--- a/app_common/traitsui/dict_editors.py
+++ b/app_common/traitsui/dict_editors.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     from traits.api import Range
 
     def value_to_trait(value):
-        return Range(low=0, high=1, value=value)
+        return Range(low=0., high=1., value=value)
 
     editor = DictValueEditor(target_dict={"a": 1, "b c": 0.5},
                              value_to_trait=value_to_trait,

--- a/app_common/traitsui/dict_editors.py
+++ b/app_common/traitsui/dict_editors.py
@@ -1,0 +1,92 @@
+from traits.api import Bool, Callable, Dict, Float, HasStrictTraits, Str
+from traitsui.api import Item, OKCancelButtons, View
+
+from app_common.std_lib.str_utils import sanitize_string
+from app_common.traitsui.common_traitsui_groups import make_window_title_group
+
+
+class DictValueEditor(HasStrictTraits):
+    """ Embeddable class to edit a dictionary's values.
+
+    Usage
+    -----
+    - Listen to changes to the target_dict's values to be notified of changes.
+    - Control the trait to use to store (and display) dict values by overriding
+    the value_to_trait callable (by default, values are stored in a Float
+    trait.)
+    - Override item_kwargs to set additional arguments on the view's Item,
+    returning Item attributes such as `label`, `readonly`, `editor`, ... By
+    default, only the label is set to the dictionary key.
+    """
+    target_dict = Dict
+
+    _trait_map = Dict
+
+    _key_map = Dict
+
+    view_klass = Callable
+
+    key_to_trait = Callable
+
+    value_to_trait = Callable(Float)
+
+    item_kwargs = Callable(lambda key: {"label": key})
+
+    title = Str
+
+    show_title_in_view = Bool
+
+    def __init__(self, **traits):
+        super(DictValueEditor, self).__init__(**traits)
+        if not self.target_dict:
+            msg = "A target dict to edit is needed to be able to edit it."
+            raise ValueError(msg)
+
+        for key, value in self.target_dict.items():
+            trait_name = self.key_to_trait(key)
+            self.add_trait(trait_name, self.value_to_trait(value))
+            self._key_map[key] = trait_name
+            self._trait_map[trait_name] = key
+            self.observe(self.update_target_dict, trait_name)
+
+    def traits_view(self):
+        item_list = []
+        if self.title and self.show_title_in_view:
+            item_list.append(make_window_title_group(self.title))
+
+        item_list += [Item(trait_name, **self.item_kwargs(key))
+                      for trait_name, key in self._trait_map.items()]
+        view = self.view_klass(
+            *item_list,
+            buttons=OKCancelButtons,
+            title=self.title
+        )
+        return view
+
+    def update_target_dict(self, event):
+        """ A trait was changed: update the dictionary.
+        """
+        self.target_dict[self._trait_map[event.name]] = event.new
+
+    def set_values(self, **kwargs):
+        """ Set dictionary values and update the corresponding traits.
+        """
+        trait_changes = {self._key_map[key]: value
+                         for key, value in kwargs.items()}
+        self.trait_set(**trait_changes)
+
+    def _key_to_trait_default(self):
+        return sanitize_string
+
+    def _view_klass_default(self):
+        return View
+
+
+if __name__ == "__main__":
+    from traits.api import Range
+
+    value_to_trait = lambda value: Range(low=0, high=1, value=value)
+    editor = DictValueEditor(target_dict={"a": 1, "b c": 0.5},
+                             value_to_trait=value_to_trait,
+                             title="Dict editor", show_title_in_view=True)
+    editor.configure_traits()

--- a/app_common/traitsui/tests/test_dict_editors.py
+++ b/app_common/traitsui/tests/test_dict_editors.py
@@ -78,7 +78,7 @@ class TestDictValueEditor(TestCase):
 
     def test_value_to_trait_func(self):
         def value_to_trait(value):
-            return Range(low=0, high=1, value=value)
+            return Range(low=0, high=10, value=value)
 
         editor = DictValueEditor(target_dict={"a": 1, "b": 2},
                                  value_to_trait=value_to_trait)

--- a/app_common/traitsui/tests/test_dict_editors.py
+++ b/app_common/traitsui/tests/test_dict_editors.py
@@ -1,0 +1,104 @@
+from unittest import TestCase
+from traits.api import Int, Range, Str, TraitError
+
+from app_common.traitsui.dict_editors import DictValueEditor
+from app_common.apptools.testing_utils import assert_obj_gui_works
+
+
+class TestDictValueEditor(TestCase):
+
+    def test_create_no_dict(self):
+        with self.assertRaises(ValueError):
+            DictValueEditor()
+
+    def test_create_dict_as_arg(self):
+        target = {"a": 1}
+        editor = DictValueEditor(target)
+        self.assertEqual(editor.target_dict, target)
+        self.assertIn("a", editor.traits())
+
+    def test_bring_up_ui(self):
+        assert_obj_gui_works(DictValueEditor(target_dict={"a": 1, "b": 2}))
+
+    def test_change_trait_changes_float_dict(self):
+        editor = DictValueEditor(target_dict={"a": 1.1, "b": 2.2})
+        self.assertIn("a", editor.traits())
+        self.assertEqual(editor.a, 1.1)
+        self.assertIn("b", editor.traits())
+        self.assertEqual(editor.b, 2.2)
+
+        editor.a = 3.3
+        self.assertEqual(editor.target_dict["a"], 3.3)
+        editor.b = -1.1
+        self.assertEqual(editor.target_dict["b"], -1.1)
+
+    def test_change_trait_changes_int_dict(self):
+        editor = DictValueEditor(target_dict={"a": 1, "b": 2},
+                                 value_to_trait=Int)
+        self.assertIn("a", editor.traits())
+        self.assertEqual(editor.a, 1)
+        self.assertIsInstance(editor.a, int)
+        self.assertIn("b", editor.traits())
+        self.assertEqual(editor.b, 2)
+        self.assertIsInstance(editor.b, int)
+
+        editor.a = 3
+        self.assertEqual(editor.target_dict["a"], 3)
+        editor.b = -1
+        self.assertEqual(editor.target_dict["b"], -1)
+
+    def test_change_trait_changes_str_dict(self):
+        editor = DictValueEditor(target_dict={"a": "1", "b": "2"},
+                                 value_to_trait=Str)
+        self.assertIn("a", editor.traits())
+        self.assertEqual(editor.a, "1")
+        self.assertIn("b", editor.traits())
+        self.assertEqual(editor.b, "2")
+
+        editor.a = "foo"
+        self.assertEqual(editor.target_dict["a"], "foo")
+        editor.b = "bar"
+        self.assertEqual(editor.target_dict["b"], "bar")
+
+    def test_set_values_1_val(self):
+        editor = DictValueEditor(target_dict={"a": 1.1, "b": 2.2})
+        editor.set_values(**{"a": 3})
+        self.assertEqual(editor.target_dict["a"], 3.)
+        self.assertEqual(editor.a, 3.)
+
+    def test_transform_keys(self):
+        editor = DictValueEditor(target_dict={"a a": 1, "b*c": 2})
+        self.assertIn("a_a", editor.traits())
+        self.assertEqual(editor.a_a, 1)
+        self.assertIn("b_c", editor.traits())
+        self.assertEqual(editor.b_c, 2)
+
+        editor.b_c = 3
+        self.assertEqual(editor.target_dict["b*c"], 3)
+
+    def test_value_to_trait_func(self):
+        value_to_trait = lambda value: Range(low=0, high=10, value=value)
+        editor = DictValueEditor(target_dict={"a": 1, "b": 2},
+                                 value_to_trait=value_to_trait)
+        self.assertIn("a", editor.traits())
+        self.assertEqual(editor.a, 1)
+        self.assertIsInstance(editor.a, int)
+        self.assertIn("b", editor.traits())
+        self.assertEqual(editor.b, 2)
+        self.assertIsInstance(editor.b, int)
+
+        editor.a = 3
+        self.assertEqual(editor.target_dict["a"], 3)
+        # Impossible because of the Range:
+        with self.assertRaises(TraitError):
+            editor.b = -1
+        self.assertEqual(editor.target_dict["b"], 2)
+
+    def test_set_values_2_vals(self):
+        editor = DictValueEditor(target_dict={"a": 1.1, "b": 2.2, "c": 3.2})
+        editor.set_values(**{"a": 3, "c": 3.3})
+        self.assertEqual(editor.target_dict["a"], 3.)
+        self.assertEqual(editor.a, 3.)
+
+        self.assertEqual(editor.target_dict["c"], 3.3)
+        self.assertEqual(editor.c, 3.3)

--- a/app_common/traitsui/tests/test_dict_editors.py
+++ b/app_common/traitsui/tests/test_dict_editors.py
@@ -77,7 +77,9 @@ class TestDictValueEditor(TestCase):
         self.assertEqual(editor.target_dict["b*c"], 3)
 
     def test_value_to_trait_func(self):
-        value_to_trait = lambda value: Range(low=0, high=10, value=value)
+        def value_to_trait(value):
+            return Range(low=0, high=1, value=value)
+
         editor = DictValueEditor(target_dict={"a": 1, "b": 2},
                                  value_to_trait=value_to_trait)
         self.assertIn("a", editor.traits())

--- a/app_common/traitsui/tests/test_dict_editors.py
+++ b/app_common/traitsui/tests/test_dict_editors.py
@@ -18,7 +18,16 @@ class TestDictValueEditor(TestCase):
         self.assertIn("a", editor.traits())
 
     def test_bring_up_ui(self):
-        assert_obj_gui_works(DictValueEditor(target_dict={"a": 1, "b": 2}))
+        editor = DictValueEditor(target_dict={"a": 1, "b": 2})
+        assert_obj_gui_works(editor)
+
+    def test_bring_up_ui_custom_item_attr(self):
+        def item_kwargs_generator(key):
+            return {"label": key, "readonly": True}
+
+        editor = DictValueEditor(target_dict={"a": 1, "b": 2},
+                                 item_kwargs=item_kwargs_generator)
+        assert_obj_gui_works(editor)
 
     def test_change_trait_changes_float_dict(self):
         editor = DictValueEditor(target_dict={"a": 1.1, "b": 2.2})

--- a/app_common/traitsui/tests/test_dict_editors.py
+++ b/app_common/traitsui/tests/test_dict_editors.py
@@ -23,7 +23,7 @@ class TestDictValueEditor(TestCase):
 
     def test_bring_up_ui_custom_item_attr(self):
         def item_kwargs_generator(key):
-            return {"label": key, "readonly": True}
+            return {"label": key, "style": "readonly"}
 
         editor = DictValueEditor(target_dict={"a": 1, "b": 2},
                                  item_kwargs=item_kwargs_generator)

--- a/etstool.py
+++ b/etstool.py
@@ -508,7 +508,7 @@ def get_parameters(runtime, toolkit, environment, **adtl_params):
         raise RuntimeError(msg.format(**parameters))
 
     if environment is None:
-        env_pattern = PKG_NAME + '-test-{toolkit}-py{runtime}'
+        env_pattern = PKG_NAME + '-develop-{toolkit}-py{runtime}'
         parameters['environment'] = env_pattern.format(**parameters)
         parameters['environment'] = parameters['environment'].replace(".", "")
     return parameters


### PR DESCRIPTION
Create a general class to edit dictionary values in a non-default way.

```
    from traits.api import Range

    def value_to_trait(value):
        return Range(low=0, high=1, value=value)

    editor = DictValueEditor(target_dict={"a": 1, "b c": 0.5},
                             value_to_trait=value_to_trait,
                             title="Dict editor", show_title_in_view=True)
    editor.configure_traits()
```
<img width="232" alt="Screen Shot 2021-01-14 at 9 21 11 AM" src="https://user-images.githubusercontent.com/593945/104610609-e46ecc80-5649-11eb-9fde-a59d325bbdb7.png">
